### PR TITLE
OSx bundle opening in GUI resolution

### DIFF
--- a/ci/travis/build.sh
+++ b/ci/travis/build.sh
@@ -33,9 +33,9 @@ if [ $TRAVIS_OS_NAME == "osx" ]
 then
     pyinstaller sakia.spec
     cp -rv dist/sakia/* dist/sakia.app/Contents/MacOS
+    cp -v res/osx/Info.plist dist/sakia.app/Contents/
     rm -rfv dist/sakia
 elif [ $TRAVIS_OS_NAME == "linux" ]
 then
     pyinstaller sakia.spec
 fi
-

--- a/res/osx/Info.plist
+++ b/res/osx/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict><key>CFBundleIdentifier</key>
+<string>sakia</string>
+<key>CFBundlePackageType</key>
+<string>APPL</string>
+<key>CFBundleName</key>
+<string>sakia</string>
+<key>CFBundleExecutable</key>
+<string>MacOS/sakia.bin</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleIconFile</key>
+<string>sakia.ico</string>
+<key>NSHighResolutionCapable</key>
+<string>True</string>
+<key>CFBundleDisplayName</key>
+<string>sakia</string>
+<key>CFBundleShortVersionString</key>
+<string>0.0.0</string>
+<key>LSBackgroundOnly</key>
+<string>False</string>
+<key>LSEnvironment</key>
+<dict>
+<key>LC_ALL</key>
+<string>UTF-8</string>
+</dict>
+</dict>
+</plist>

--- a/sakia.spec
+++ b/sakia.spec
@@ -97,10 +97,4 @@ if is_darwin:
     app = BUNDLE(exe,
          name='sakia.app',
          icon='sakia.ico',
-         bundle_identifier=None,
-         info_plist={
-        'NSHighResolutionCapable': 'True',
-        'LSBackgroundOnly': 'False'
-        },)
-
-
+         bundle_identifier=None,) # take care, info.plist will be overridden.


### PR DESCRIPTION
We need to enforce locale environment variable for encoding to be
able to read files.

But this can not be created directly by the spec file, then we need
to enforce the Info.plist file

Here is why (extract from https://pythonhosted.org/PyInstaller/spec-files.html#spec-file-options-for-a-mac-os-x-bundle):
The info_plist= parameter only handles simple key:value pairs. It cannot handle nested XML arrays. For example, if you want to modify Info.plist to tell Mac OS X what filetypes your app supports, you must add a CFBundleDocumentTypes entry to Info.plist (see Apple document types). The value of that keyword is a list of dicts, each containing up to five key:value pairs.

To add such a value to your app’s Info.plist you must edit the plist file separately after PyInstaller has created the app. However, when you re-run PyInstaller, your changes will be wiped out. One solution is to prepare a complete Info.plist file and copy it into the app after creating it.